### PR TITLE
Rebasing fix and test set

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,7 @@ gulp.task('pre-test', function () {
 });
 
 gulp.task('test', ['pre-test'], function () {
-  return gulp.src('test/test.js')
+  return gulp.src('test/*.js')
     .pipe(mocha({reporter: 'list'}))
     .pipe(istanbul.writeReports({
       includeUntested: true,

--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ module.exports = function gulpCleanCSS(options, callback) {
 
     var fileOptions = objectAssign({target: file.path}, options);
 
-    if (!fileOptions.relativeTo && (fileOptions.root || file.path))
-      fileOptions.relativeTo = path.dirname(path.resolve(options.root || file.path));
+    if (!fileOptions.relativeTo && file.path)
+      fileOptions.relativeTo = path.dirname(path.resolve(file.path));
 
     if (file.sourceMap)
       fileOptions.sourceMap = JSON.parse(JSON.stringify(file.sourceMap));

--- a/test/fixtures/rebasing/otherdir/fromroot.css
+++ b/test/fixtures/rebasing/otherdir/fromroot.css
@@ -1,0 +1,4 @@
+p.fromroot
+{
+    background: url(../sbudir/insubdir.png);
+}

--- a/test/fixtures/rebasing/otherdir/imported.css
+++ b/test/fixtures/rebasing/otherdir/imported.css
@@ -1,0 +1,18 @@
+@import url(nestedsub/nested.css);
+
+p.imported_same
+{
+    background: url(imported.png);
+}
+p.imported_parent
+{
+    background: url(../parent.png);
+}
+p.imported_other
+{
+    background: url(../othersub/inother.png);
+}
+p.imported_absolute
+{
+    background: url(/inroot.png);
+}

--- a/test/fixtures/rebasing/otherdir/nestedsub/nested.css
+++ b/test/fixtures/rebasing/otherdir/nestedsub/nested.css
@@ -1,0 +1,4 @@
+p.imported_nested
+{
+    background: url(nested.png);
+}

--- a/test/fixtures/rebasing/root.css
+++ b/test/fixtures/rebasing/root.css
@@ -1,0 +1,5 @@
+@import url(otherdir/fromroot.css);
+p.root
+{
+    background: url(inroot.png);
+}

--- a/test/fixtures/rebasing/subdir/import.css
+++ b/test/fixtures/rebasing/subdir/import.css
@@ -1,0 +1,7 @@
+@import url(../otherdir/imported.css);
+@import url(insub.css);
+
+p.import
+{
+    background: url(import.png);
+}

--- a/test/fixtures/rebasing/subdir/import_absolute.css
+++ b/test/fixtures/rebasing/subdir/import_absolute.css
@@ -1,0 +1,8 @@
+@import url(../otherdir/imported.css);
+@import url(/rebasing/subdir/insub.css);
+@import url(/rebasing/root.css);
+
+p.import
+{
+    background: url(import.png);
+}

--- a/test/fixtures/rebasing/subdir/insub.css
+++ b/test/fixtures/rebasing/subdir/insub.css
@@ -1,0 +1,21 @@
+
+p.insub_same
+{
+    background: url(insub.png);
+}
+p.insub_child
+{
+    background url(child/child.png);
+}
+p.insub_parent
+{
+    background: url(../parent.png);
+}
+p.insub_other
+{
+    background: url(../othersub/inother.png);
+}
+p.insub_absolute
+{
+    background: url(/inroot.png);
+}

--- a/test/rebasing.js
+++ b/test/rebasing.js
@@ -1,0 +1,202 @@
+const buffer = require('vinyl-buffer');
+const chai = require('chai');
+const cleanCSS = require('..');
+const concat = require('gulp-concat');
+const del = require('del');
+const expect = chai.expect;
+const File = require('vinyl');
+const gulp = require('gulp');
+const gulpSass = require('gulp-sass');
+const rename = require('gulp-rename');
+const sourcemaps = require('gulp-sourcemaps');
+const vfsFake = require('vinyl-fs-fake');
+
+chai.should();
+
+describe('gulp-clean-css: rebase', function () {
+
+  it('should not rebase files by default', function (done) {
+
+    // CLI: cleancss test/fixtures/rebasing/subdir/insub.css
+    gulp.src(['test/fixtures/rebasing/subdir/insub.css'])
+      .pipe(cleanCSS())
+      .on('data', function(file) {
+        expect(file.contents.toString()).to.equal(
+        'p.insub_same{background:url(insub.png)}' +
+        'p.insub_parent{background:url(../parent.png)}' +
+        'p.insub_other{background:url(../othersub/inother.png)}' +
+        'p.insub_absolute{background:url(/inroot.png)}'
+        );
+      })
+      .once('end', function () {
+        done();
+      });
+  });
+
+  // CLI: cleancss test/fixtures/rebasing/subdir/insub.css -o test/fixtures/rebasing/min.generated.css
+  it('should by rebase files with target specified', function (done) {
+    gulp.src(['test/fixtures/rebasing/subdir/insub.css'])
+      .pipe(cleanCSS({target: 'test/fixtures/rebasing/min.generated.css'}))
+      .on('data', function (file) {
+        expect(file.contents.toString()).to.equal(
+          'p.insub_same{background:url(subdir/insub.png)}' +
+          'p.insub_parent{background:url(parent.png)}' +
+          'p.insub_other{background:url(othersub/inother.png)}' +
+          'p.insub_absolute{background:url(/inroot.png)}'
+        );
+      })
+      .once('end', function () {
+        done();
+      });
+  });
+
+  // CLI: cleancss test/fixtures/rebasing/subdir/insub.css -o test/fixtures/rebasing/subdir/min.generated.css
+  it('should by rebase files with target in subdir specified', function (done) {
+    gulp.src(['test/fixtures/rebasing/subdir/insub.css'])
+      .pipe(cleanCSS({target: 'test/fixtures/rebasing/subdir/min.generated.css'}))
+      .on('data', function (file) {
+        expect(file.contents.toString()).to.equal(
+          'p.insub_same{background:url(insub.png)}' +
+          'p.insub_parent{background:url(../parent.png)}' +
+          'p.insub_other{background:url(../othersub/inother.png)}' +
+          'p.insub_absolute{background:url(/inroot.png)}'
+        );
+      })
+      .once('end', function () {
+        done();
+      });
+  });
+
+  // CLI: cleancss test/fixtures/rebasing/subdir/insub.css --root test/fixtures/rebasing/
+  it('should rebase files with root specified', function (done) {
+    gulp.src(['test/fixtures/rebasing/subdir/insub.css'])
+      .pipe(cleanCSS({root: 'test/fixtures/rebasing/'}))
+      .on('data', function (file) {
+        expect(file.contents.toString()).to.equal(
+         'p.insub_same{background:url(/subdir/insub.png)}' +
+         'p.insub_parent{background:url(/parent.png)}' +
+         'p.insub_other{background:url(/othersub/inother.png)}' +
+         'p.insub_absolute{background:url(/inroot.png)}'
+        );
+      })
+      .once('end', function () {
+        done();
+      })
+  });
+
+  // CLI: cleancss test/fixtures/rebasing/subdir/insub.css --root test/fixtures/rebasing/ -o test/fixtures/rebasing/subdir/min.generated.css
+  it('should rebase files with root and target specified', function (done) {
+    gulp.src(['test/fixtures/rebasing/subdir/insub.css'])
+      .pipe(cleanCSS({
+        root : 'test/fixtures/rebasing/',
+        target : 'test/fixtures/rebasing/subdir/min.generated.css'
+      }))
+      .on('data', function (file) {
+        expect(file.contents.toString()).to.equal(
+         'p.insub_same{background:url(/subdir/insub.png)}' +
+         'p.insub_parent{background:url(/parent.png)}' +
+         'p.insub_other{background:url(/othersub/inother.png)}' +
+         'p.insub_absolute{background:url(/inroot.png)}'
+        );
+      })
+      .once('end', function () {
+        done();
+      })
+  });
+
+  // CLI: cleancss test/fixtures/rebasing/subdir/import.css
+  it('should resolve imports correctly', function (done) {
+    gulp.src(['test/fixtures/rebasing/subdir/import.css'])
+      .pipe(cleanCSS())
+      .on('data', function (file) {
+        expect(file.contents.toString()).to.equal(
+         'p.imported_nested{background:url(../otherdir/nestedsub/nested.png)}' +
+         'p.imported_same{background:url(../otherdir/imported.png)}' +
+         'p.imported_parent{background:url(../parent.png)}' +
+         'p.imported_other{background:url(../othersub/inother.png)}' +
+         'p.imported_absolute{background:url(/inroot.png)}' +
+         'p.insub_same{background:url(insub.png)}' +
+         'p.insub_parent{background:url(../parent.png)}' +
+         'p.insub_other{background:url(../othersub/inother.png)}' +
+         'p.insub_absolute{background:url(/inroot.png)}' +
+         'p.import{background:url(import.png)}'
+        );
+      })
+      .once('end', function () {
+        done();
+      })
+  });
+
+  // CLI: cleancss test/fixtures/rebasing/subdir/import.css -o test/fixtures/root.generated.css
+  it('should resolve imports with target set correctly', function (done) {
+    gulp.src(['test/fixtures/rebasing/subdir/import.css'])
+      .pipe(cleanCSS({target: 'test/fixtures/root.generated.css'}))
+      .on('data', function (file) {
+        expect(file.contents.toString()).to.equal(
+          'p.imported_nested{background:url(rebasing/otherdir/nestedsub/nested.png)}' +
+          'p.imported_same{background:url(rebasing/otherdir/imported.png)}' +
+          'p.imported_parent{background:url(rebasing/parent.png)}' +
+          'p.imported_other{background:url(rebasing/othersub/inother.png)}' +
+          'p.imported_absolute{background:url(/inroot.png)}' +
+          'p.insub_same{background:url(rebasing/subdir/insub.png)}' +
+          'p.insub_parent{background:url(rebasing/parent.png)}' +
+          'p.insub_other{background:url(rebasing/othersub/inother.png)}' +
+          'p.insub_absolute{background:url(/inroot.png)}' +
+          'p.import{background:url(rebasing/subdir/import.png)}'
+        );
+      })
+      .once('end', function () {
+        done();
+      })
+  });
+
+  // CLI: cleancss test/fixtures/rebasing/subdir/import_absolute.css --root test/fixtures/
+  it('should resolve absolute imports with root set correctly', function (done) {
+    gulp.src(['test/fixtures/rebasing/subdir/import_absolute.css'])
+      .pipe(cleanCSS({root: 'test/fixtures/'}))
+      .on('data', function (file) {
+        expect(file.contents.toString()).to.equal(
+         'p.imported_nested{background:url(/rebasing/otherdir/nestedsub/nested.png)}' +
+         'p.imported_same{background:url(/rebasing/otherdir/imported.png)}' +
+         'p.imported_parent{background:url(/rebasing/parent.png)}' +
+         'p.imported_other{background:url(/rebasing/othersub/inother.png)}' +
+         'p.imported_absolute{background:url(/inroot.png)}' +
+         'p.insub_same{background:url(/rebasing/subdir/insub.png)}' +
+         'p.insub_parent{background:url(/rebasing/parent.png)}' +
+         'p.insub_other{background:url(/rebasing/othersub/inother.png)}' +
+         'p.insub_absolute{background:url(/inroot.png)}' +
+         'p.fromroot{background:url(/rebasing/sbudir/insubdir.png)}' +
+         'p.root{background:url(/rebasing/inroot.png)}' +
+         'p.import{background:url(/rebasing/subdir/import.png)}'
+        );
+      })
+      .once('end', function () {
+        done();
+      })
+  });
+
+  // CLI: cleancss test/fixtures/rebasing/subdir/import_absolute.css --root test/fixtures/ -o test/fixtures/rebasing/subdir/min.generated.css
+  it('should resolve imports with root and target set correctly', function (done) {
+    gulp.src(['test/fixtures/rebasing/subdir/import_absolute.css'])
+      .pipe(cleanCSS({root: 'test/fixtures/', target : 'test/fixtures/rebasing/subdir/min.generated.css'}))
+      .on('data', function (file) {
+        expect(file.contents.toString()).to.equal(
+       'p.imported_nested{background:url(/rebasing/otherdir/nestedsub/nested.png)}' +
+       'p.imported_same{background:url(/rebasing/otherdir/imported.png)}' +
+       'p.imported_parent{background:url(/rebasing/parent.png)}' +
+       'p.imported_other{background:url(/rebasing/othersub/inother.png)}' +
+       'p.imported_absolute{background:url(/inroot.png)}' +
+       'p.insub_same{background:url(/rebasing/subdir/insub.png)}' +
+       'p.insub_parent{background:url(/rebasing/parent.png)}' +
+       'p.insub_other{background:url(/rebasing/othersub/inother.png)}' +
+       'p.insub_absolute{background:url(/inroot.png)}' +
+       'p.fromroot{background:url(/rebasing/sbudir/insubdir.png)}' +
+       'p.root{background:url(/rebasing/inroot.png)}' +
+       'p.import{background:url(/rebasing/subdir/import.png)}'
+        );
+      })
+      .once('end', function () {
+        done();
+      })
+  });
+});


### PR DESCRIPTION
Because of issues #8 and #22, I've written a test set for several rebase scenarios, based on how the command line version of cleancss behaves (the commands are in the comments of the tests). To get the correct behavior, a small fix in gulp-clean-css is necessary.