### PR TITLE
Changed CleanCSS invokation with filepath as argument instead of file content

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,9 +24,9 @@ module.exports = function gulpCleanCSS(options, callback) {
     if (file.sourceMap)
       options.sourceMap = JSON.parse(JSON.stringify(file.sourceMap));
 
-    var style = file.contents ? file.contents.toString() : '';
+    // var style = file.contents ? file.contents.toString() : '';
 
-    new CleanCSS(options).minify(style, function (errors, css) {
+    new CleanCSS(options).minify([file.path], function (errors, css) {
 
       if (errors)
         return cb(errors.join(' '));


### PR DESCRIPTION
With this change my code works again using `gulp-clean-css@3.0.3` and import problem from #31 is fixed.
But some tests are failing.

The only thing that's changed: not source file content but file path is passed to the `minify()` function, so CleanCSS knows the source location and can import relative URL's from the files perspective.