### PR TITLE
inlined imports should be rebased to current file

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,10 @@ module.exports = function gulpCleanCSS(options, callback) {
       options.sourceMap = JSON.parse(JSON.stringify(file.sourceMap));
 
     let contents = file.contents ? file.contents.toString() : '';
-    let pass = options.rebaseTo ? {[file.path]: {styles: contents}} : contents;
+    let pass = {[file.path]: {styles: contents}};
+    if (!options.rebaseTo && options.rebase!==false){
+        options.rebaseTo = path.dirname(file.path);
+    }
 
     new CleanCSS(options).minify(pass, function (errors, css) {
 

--- a/test/test.js
+++ b/test/test.js
@@ -226,7 +226,7 @@ describe('gulp-clean-css: base functionality', function () {
     .pipe(cleanCSS({debug: true}, function (details) {
       expect(details.warnings).to.exist &&
       expect(details.warnings.length).to.equal(1) &&
-      expect(details.warnings[0]).to.equal('Missing \'}\' at 1:14.');
+      expect(details.warnings[0]).to.equal('Missing \'}\' at fixtures/test.css:1:14.');
     }))
     .on('data', function (file) {
       i += 1;
@@ -302,6 +302,32 @@ describe('gulp-clean-css: rebase', function () {
       let actual = file.contents.toString();
 
       expect(actual).to.equalIgnoreSpaces(expected);
+    })
+    .once('end', done);
+  });
+  
+  it('should rebase to current relative file location - relative imports are resolved like in the browser', function (done) {
+
+    gulp.src(['test/fixtures/rebasing/subdir/import.css'])
+    .pipe(cleanCSS({}))
+    .on('data', function (file) {
+
+      let expected = `
+        p.imported_nested{background:url(../otherdir/nestedsub/nested.png)}
+        p.imported_same{background:url(../otherdir/imported.png)}
+        p.imported_parent{background:url(../parent.png)}
+        p.imported_other{background:url(../othersub/inother.png)}
+        p.imported_absolute{background:url(/inroot.png)}
+        p.insub_same{background:url(insub.png)}
+        p.insub_child{background:url(child/child.png)}
+        p.insub_parent{background:url(../parent.png)}
+        p.insub_other{background:url(../othersub/inother.png)}
+        p.insub_absolute{background:url(/inroot.png)}
+        p.import{background:url(import.png)}`;
+
+      let actual = file.contents.toString();
+
+      expect(actual).to.equalIgnoreSpaces(expected)
     })
     .once('end', done);
   });


### PR DESCRIPTION
My problem is related to #42 

**Problem description**

File `import.css`:

```
@import url(../otherdir/imported.css);
p.import
{
    background: url(import.png);
}
```

File `otherdir/imported.css`

```
p.imported
{
    background: url(import2.png);
}
```

Will fail by:

```
gulp.src(['dir/import.css'])
.pipe(cleanCSS({}))
.pipe(gulp.dest("out"))
```

with an Exception that `../otherdir/imported.css` can not be resolved.

I had expected an outcome like this:

minified 'import.css':

```
p.imported{background:url(../otherdir/import2.png);}
p.import{background:url(import.png);}
```


I was not able to fix this problem by configuration, because the path of the current file is required to correct the `rebaseTo` option.

**Solution**

This fix always transports the file.path together with the contents to CleanCss.minify, which enables the imports of relative files.

A second problem occurred when `inline: ['local']` is required. The image URLs defined in the imported css files were unexpected rebased to the current working directory. I had expected a rebase relative to the current file, so that the browser can import e.g. all images relative from the minified css file. Like in the sample above.

The patch ensures that the rebaseTo option is defined as the parent directory of the current processed file if not otherwise specified.