### PR TITLE
Avoid sharing _options across multiple streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,11 @@ const through = require('through2');
 
 module.exports = (options, callback) => {
 
-  let _options = Object.assign({}, options || {});
   let _callback = callback || (o => undefined);
 
   return through.obj(function (file, enc, cb) {
+
+    let _options = Object.assign({}, options || {});
 
     if (file.isStream()) {
       this.emit('error', new PluginError('gulp-clean-css', 'Streaming not supported!'));


### PR DESCRIPTION
node: v8.15.0.

Before this commit, variable _options is sharing multiple streams.
It causes problems. _options.rebaseTo that was always set first is used.

If we have below files and gulpfile.js, rebaseTo was always `<PROJECT_ROOT>/scss/entries/lp/lp1/css`, and never `<PROJECT_ROOT/scss/entries/lp/lp2/subpage/css>`

```
scss/entries/lp/lp1/css/index.scss
scss/entries/lp/lp2/subpage/css/index.scss

gulp
  .src('scss/entries/**/*.scss')
  .pipe(plumber())
  .pipe(sass())
  .pipe(cleanCSS()) // rebaseTo always 'scss/entries/apps/app1/css/',
  .pipe(gulp.dest('public/'));
```

EDIT: This changes breaks backwards compatibility.