### PR TITLE
Fix Issue #85, aborting without diagnostic message.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = (options, callback) => {
     new CleanCSS(_options).minify(content, (errors, css) => {
 
       if (errors) {
-        return cb(errors.join(' '));
+        return cb(new Error(errors.join(' ')));
       }
 
       let details = {


### PR DESCRIPTION
Fix parameter type passed to callback when errors are received from CleanCSS.minify.  (See issue #85)